### PR TITLE
ユーザー後攻時の初手で、CPUが○を打たないときがある問題を修正

### DIFF
--- a/app/src/main/java/com/example/yanai/a3mokunarabe/MainActivity.java
+++ b/app/src/main/java/com/example/yanai/a3mokunarabe/MainActivity.java
@@ -246,6 +246,8 @@ public class MainActivity extends AppCompatActivity implements OnClickListener {
 
         } else if (isMyTurn == "×") {
 
+            button.setText("×");
+
             //turnCountが0〜3の4回のときは、◯を自動で打つように
             if (turnCount <= 3) {
                 //はじめはsetPCturnは実行されるようにtrueにしておく
@@ -260,7 +262,6 @@ public class MainActivity extends AppCompatActivity implements OnClickListener {
                 decideWinner("◯");
             }
 
-            button.setText("×");
             decideWinner("×");
 
             button.setEnabled(false);


### PR DESCRIPTION
`button.setText("×");`の記述位置を上の方に移動しました。ユーザーが×を打ったボタンと、CPUがランダムに○を打つボタンが、重なってしまうことが原因で、CPUが○を打たないように見えていました。先に×でボタンを埋めてしまうことで、CPUが空のボタンを探すことができるようになります。
